### PR TITLE
Fix compiling on Xcode 12.X

### DIFF
--- a/Sources/SwiftyContacts/SwiftyContacts.swift
+++ b/Sources/SwiftyContacts/SwiftyContacts.swift
@@ -25,6 +25,7 @@ class ContactStore {
     static var `default` = CNContactStore()
 }
 
+#if compiler(>=5.5) && canImport(_Concurrency)
 /// Requests access to the user's contacts.
 /// - Throws: Error information, if an error occurred.
 /// - Returns: returns  true if the user allows access to contacts
@@ -32,6 +33,7 @@ class ContactStore {
 public func requestAccess() async throws -> Bool {
     return try await ContactStore.default.requestAccess(for: .contacts)
 }
+#endif
 
 /// Indicates the current authorization status to access contact data.
 /// - Returns: Returns the authorization status for the given entityType.
@@ -39,6 +41,7 @@ public func authorizationStatus() -> CNAuthorizationStatus {
     return CNContactStore.authorizationStatus(for: .contacts)
 }
 
+#if compiler(>=5.5) && canImport(_Concurrency)
 /// Fetch all contacts from device
 /// - Parameters:
 ///   - keysToFetch: The contact fetch request that specifies the search criteria.
@@ -63,6 +66,7 @@ public func fetchContacts(keysToFetch: [CNKeyDescriptor] = [CNContactVCardSerial
         }
     }
 }
+#endif
 
 /// fetch contacts matching a conditions.
 /// - Parameters:

--- a/Tests/SwiftyContactsTests/SwiftyContactsTests.swift
+++ b/Tests/SwiftyContactsTests/SwiftyContactsTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 @available(macOS 12.0.0, *)
 final class SwiftyContactsTests: XCTestCase {
+    #if compiler(>=5.5) && canImport(_Concurrency)
     func testRequestAccess() async {
         do {
             let bool = try await requestAccess()
@@ -11,6 +12,7 @@ final class SwiftyContactsTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
+    #endif
 
     func testAuthorizationStatus() {
         XCTAssertEqual(authorizationStatus(), CNAuthorizationStatus.authorized)
@@ -36,7 +38,8 @@ final class SwiftyContactsTests: XCTestCase {
             }
         }
     }
-
+    
+    #if compiler(>=5.5) && canImport(_Concurrency)
     func testFetchContacts() async {
         do {
             let contacts = try await fetchContacts()
@@ -45,6 +48,7 @@ final class SwiftyContactsTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
+    #endif
 
     func testFetchContactsClosures() {
         let e = expectation(description: "testRequestAccessClosures")


### PR DESCRIPTION
The latest version breaks compiling on older versions of Xcode because `async` and `await` are invalid keywords. The proper compiler directives are required